### PR TITLE
Update internal `FossilError` class

### DIFF
--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -16,10 +16,12 @@ import { throttle } from './decorators';
 type Distinct<T, DistinctName> = T & { __TYPE__: DistinctName };
 /** path to .fossil */
 export type FossilPath = Distinct<string, 'path to .fossil'>;
+/** local repository root */
+export type FossilRoot = Distinct<string, 'local repository root'>;
 /** cwd for executing fossil */
-export type FossilCWD = Distinct<string, 'cwd for executing fossil'>;
-/** local root */
-export type FossilRoot = Distinct<FossilCWD, 'local root'>;
+export type FossilCWD =
+    | Distinct<string, 'cwd for executing fossil'>
+    | FossilRoot;
 /** URI for the close
  *
  * * http[s]://[userid[:password]@]host[:port][/path]

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -115,7 +115,8 @@ export interface FossilFindAttemptLogger {
 }
 
 interface FossilSpawnOptions extends cp.SpawnOptionsWithoutStdio {
-    logErrors?: boolean;
+    cwd: FossilCWD;
+    logErrors?: boolean; // whether to log stderr to the fossil outputChannel
 }
 
 export class FossilFinder {
@@ -249,6 +250,7 @@ export interface IFossilErrorData {
     exitCode?: number;
     fossilErrorCode?: FossilErrorCode;
     fossilCommand?: string;
+    cwd?: FossilCWD;
 }
 
 export class FossilError implements IFossilErrorData {
@@ -259,14 +261,16 @@ export class FossilError implements IFossilErrorData {
     fossilErrorCode: FossilErrorCode;
     fossilCommand: string;
     untrackedFilenames?: string[];
+    cwd?: FossilCWD;
 
     constructor(data: IFossilErrorData) {
-        this.message = data.message || 'Fossil error';
-        this.stdout = data.stdout || '';
-        this.stderr = data.stderr || '';
+        this.message = data.message ?? 'Fossil error';
+        this.stdout = data.stdout ?? '';
+        this.stderr = data.stderr ?? '';
         this.exitCode = data.exitCode;
-        this.fossilErrorCode = data.fossilErrorCode || 'unknown';
-        this.fossilCommand = data.fossilCommand || '';
+        this.fossilErrorCode = data.fossilErrorCode ?? 'unknown';
+        this.fossilCommand = data.fossilCommand ?? '';
+        this.cwd = data.cwd;
     }
 
     toString(): string {
@@ -280,8 +284,9 @@ export class FossilError implements IFossilErrorData {
                     fossilCommand: this.fossilCommand,
                     stdout: this.stdout,
                     stderr: this.stderr,
+                    cwd: this.cwd,
                 },
-                [],
+                null,
                 2
             );
 
@@ -460,6 +465,7 @@ export class Fossil {
                     exitCode: result.exitCode,
                     fossilErrorCode,
                     fossilCommand: args[0],
+                    cwd: options.cwd,
                 })
             );
         }

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -166,6 +166,7 @@ export class FossilFinder {
 }
 
 export interface IExecutionResult {
+    fossilPath: FossilExecutablePath;
     exitCode: number;
     stdout: string;
     stderr: string;
@@ -262,7 +263,7 @@ async function exec(
 
     dispose(disposables);
 
-    return { exitCode, stdout, stderr, args, cwd: options.cwd };
+    return { fossilPath, exitCode, stdout, stderr, args, cwd: options.cwd };
 }
 
 export interface IFossilErrorData extends IExecutionResult {
@@ -271,16 +272,18 @@ export interface IFossilErrorData extends IExecutionResult {
 }
 
 export class FossilError implements IFossilErrorData {
-    message: string;
-    stdout: string;
-    stderr: string;
-    exitCode: number;
+    readonly fossilPath: FossilExecutablePath;
+    readonly message: string;
+    readonly stdout: string;
+    readonly stderr: string;
+    readonly exitCode: number;
     fossilErrorCode: FossilErrorCode;
-    args: string[];
+    readonly args: string[];
     untrackedFilenames?: string[];
-    cwd: FossilCWD;
+    readonly cwd: FossilCWD;
 
     constructor(data: IFossilErrorData) {
+        this.fossilPath = data.fossilPath;
         this.message = data.message;
         this.stdout = data.stdout;
         this.stderr = data.stderr;
@@ -302,6 +305,7 @@ export class FossilError implements IFossilErrorData {
                     stdout: this.stdout,
                     stderr: this.stderr,
                     cwd: this.cwd,
+                    fossilPath: this.fossilPath,
                 },
                 null,
                 2

--- a/src/model.ts
+++ b/src/model.ts
@@ -261,7 +261,7 @@ export class Model implements Disposable {
             // case insensitive file systems
             // https://github.com/Microsoft/vscode/issues/33498
 
-            if (this.getRepository(repositoryRoot)) {
+            if (this.getRepository(Uri.file(repositoryRoot))) {
                 return true;
             }
 

--- a/src/resourceGroups.ts
+++ b/src/resourceGroups.ts
@@ -1,4 +1,4 @@
-import { FossilError, IFileStatus } from './fossilBase';
+import { IFileStatus } from './fossilBase';
 import {
     Uri,
     SourceControlResourceGroup,
@@ -179,9 +179,7 @@ export function groupStatuses({
                 status = Status.CONFLICT;
                 break;
             default:
-                throw new FossilError({
-                    message: 'Unknown rawStatus: ' + rawStatus,
-                });
+                throw new Error('Unknown rawStatus: ' + rawStatus);
         }
 
         if (status === Status.UNTRACKED) {

--- a/src/test/suite/common.ts
+++ b/src/test/suite/common.ts
@@ -36,14 +36,14 @@ export async function fossilInit(
 
     await vscode.commands.executeCommand('fossil.init');
     assert.ok(showSaveDialogstub.calledOnce);
-    assert.ok(
-        fs.existsSync(fossilPath.fsPath),
-        `Not a file: '${fossilPath.fsPath}'`
-    );
-    assert.ok(showInformationMessage.calledOnce);
     if (fossil.version >= [2, 18]) {
         assert.ok(showInputBox.calledTwice);
     }
+    assert.ok(
+        fs.existsSync(fossilPath.fsPath),
+        `Not a file: '${fossilPath.fsPath}' even though 'fossil.init' was sucessfully executed`
+    );
+    assert.ok(showInformationMessage.calledOnce);
     sandbox.restore();
 }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,6 +17,7 @@ import {
     fossil_undo_and_redo_warning,
     fossil_undo_and_redo_working,
 } from './test_undo_redo';
+import { error_is_thrown_when_executing_unknown_command } from './test_utils';
 
 async function createFossil(): Promise<Fossil> {
     const outputChannel = window.createOutputChannel('Fossil.Test');
@@ -50,6 +51,10 @@ suite('Fossil', () => {
 
     afterEach(() => {
         sandbox.restore();
+    });
+
+    test('fossil.error', async () => {
+        await error_is_thrown_when_executing_unknown_command(sandbox, fossil);
     });
 
     test('fossil.init', async () => {

--- a/src/test/suite/test_utils.ts
+++ b/src/test/suite/test_utils.ts
@@ -16,7 +16,7 @@ export async function error_is_thrown_when_executing_unknown_command(
         stderr: 'fossil: unknown command: fizzbuzz\nfossil: use "help" for more information\n',
         stdout: '',
         exitCode: 1,
-        fossilCommand: 'fizzbuzz',
+        args: ['fizzbuzz'],
         fossilErrorCode: 'unknown',
         cwd: cwd,
     });
@@ -28,13 +28,15 @@ export async function error_is_thrown_when_executing_unknown_command(
         stderr: 'my stderror',
         exitCode: 0,
         fossilErrorCode: 'unknown',
-        fossilCommand: 'help',
+        args: ['help'],
         cwd: 'cwd' as FossilCWD,
     });
     const referenceString = `my message {
   "exitCode": 0,
   "fossilErrorCode": "unknown",
-  "fossilCommand": "help",
+  "args": [
+    "help"
+  ],
   "stdout": "my staout",
   "stderr": "my stderror",
   "cwd": "cwd"

--- a/src/test/suite/test_utils.ts
+++ b/src/test/suite/test_utils.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { Fossil, FossilCWD, FossilError } from '../../fossilBase';
+import {
+    Fossil,
+    FossilCWD,
+    FossilError,
+    FossilExecutablePath,
+} from '../../fossilBase';
 import * as assert from 'assert/strict';
 
 export async function error_is_thrown_when_executing_unknown_command(
@@ -30,6 +35,7 @@ export async function error_is_thrown_when_executing_unknown_command(
         fossilErrorCode: 'unknown',
         args: ['help'],
         cwd: 'cwd' as FossilCWD,
+        fossilPath: '/bin/fossil' as FossilExecutablePath,
     });
     const referenceString = `my message {
   "exitCode": 0,
@@ -39,7 +45,8 @@ export async function error_is_thrown_when_executing_unknown_command(
   ],
   "stdout": "my staout",
   "stderr": "my stderror",
-  "cwd": "cwd"
+  "cwd": "cwd",
+  "fossilPath": "/bin/fossil"
 }`;
     assert.equal(TestError.toString(), referenceString);
 }

--- a/src/test/suite/test_utils.ts
+++ b/src/test/suite/test_utils.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { Fossil, FossilCWD, FossilError } from '../../fossilBase';
+import * as assert from 'assert/strict';
+
+export async function error_is_thrown_when_executing_unknown_command(
+    sandbox: sinon.SinonSandbox,
+    fossil: Fossil
+): Promise<void> {
+    const rootUri = vscode.workspace.workspaceFolders![0].uri;
+    const cwd = rootUri.fsPath as FossilCWD;
+    const showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage');
+    showErrorMessage.resolves(undefined);
+    await assert.rejects(fossil.exec(cwd, ['fizzbuzz']), {
+        message: 'Failed to execute fossil',
+        stderr: 'fossil: unknown command: fizzbuzz\nfossil: use "help" for more information\n',
+        stdout: '',
+        exitCode: 1,
+        fossilCommand: 'fizzbuzz',
+        fossilErrorCode: 'unknown',
+        cwd: cwd,
+    });
+    assert.ok(showErrorMessage.calledOnce);
+
+    const TestError = new FossilError({
+        message: 'my message',
+        stdout: 'my staout',
+        stderr: 'my stderror',
+        exitCode: 0,
+        fossilErrorCode: 'unknown',
+        fossilCommand: 'help',
+        cwd: 'cwd' as FossilCWD,
+    });
+    const referenceString = `my message {
+  "exitCode": 0,
+  "fossilErrorCode": "unknown",
+  "fossilCommand": "help",
+  "stdout": "my staout",
+  "stderr": "my stderror",
+  "cwd": "cwd"
+}`;
+    assert.equal(TestError.toString(), referenceString);
+}


### PR DESCRIPTION
* simplify `FossilError` class
* add `fossilPath`, `args` and `cwd` parameters to the `FossilError` class

should help debug errors easier