### PR TITLE
hg cleanup and code refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,15 @@
         "anypath",
         "Checkin",
         "cherrypick",
+        "Crowl",
         "esbuild",
         "fslckout",
         "humanise",
         "outfile",
         "repourl",
         "sequentialize",
-        "Technote"
+        "Technote",
+        "unstage",
+        "userid"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,20 +3,16 @@
     "files.exclude": {
         "out": true,
         "**/.git": true,
-        "**/.svn": true,
-        "**/.hg": true,
-        "**/CVS": true,
-        "_FOSSIL_": true,
         ".fossil-settings/*.no-warn": true,
         "**/.DS_Store": true,
-        "*.vsix": true,
-        "images/production": true
+        "*.vsix": true
     },
     "cSpell.words": [
         "anypath",
         "Checkin",
         "cherrypick",
         "esbuild",
+        "fslckout",
         "humanise",
         "outfile",
         "repourl",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -168,7 +168,7 @@ export class CommandCenter {
             await window.showTextDocument(document, opts);
             return;
         }
-        return await commands.executeCommand<void>(
+        return commands.executeCommand<void>(
             'vscode.diff',
             left,
             right,
@@ -491,7 +491,7 @@ export class CommandCenter {
             return;
         }
 
-        return await this.openFile(resource);
+        return this.openFile(resource);
     }
 
     @command('fossil.openChangeFromUri')
@@ -502,7 +502,7 @@ export class CommandCenter {
             return;
         }
 
-        return await this._openResource(resource);
+        return this._openResource(resource);
     }
 
     @command('fossil.ignore')
@@ -537,7 +537,7 @@ export class CommandCenter {
 
     @command('fossil.addAll', { repository: true })
     async addAll(repository: Repository): Promise<void> {
-        return await repository.add();
+        return repository.add();
     }
 
     @command('fossil.add')
@@ -699,7 +699,7 @@ export class CommandCenter {
 
     @command('fossil.unstageAll', { repository: true })
     async unstageAll(repository: Repository): Promise<void> {
-        return await repository.unstage();
+        return repository.unstage();
     }
 
     @command('fossil.revert')
@@ -1455,7 +1455,7 @@ export class CommandCenter {
         const relativePath = repository.mapFileUriToWorkspaceRelativePath(uri);
         const title = `${relativePath} (${fromName} vs. ${toName})`;
 
-        return await commands.executeCommand<void>(
+        return commands.executeCommand<void>(
             'vscode.diff',
             fromUri,
             toUri,

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -114,7 +114,7 @@ export class FossilContentProvider {
         const params = fromFossilUri(uri);
 
         try {
-            return await repository.show(params);
+            return repository.show(params);
         } catch (err) {
             // no-op
         }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -85,6 +85,7 @@ function _throttle<T>(fn: Function, key: string): Function {
 
 export const throttle = decorate(_throttle);
 
+// Make sure asynchronous functions are called one after another (untested).
 function _sequentialize(fn: Function, key: string): Function {
     const currentKey = `__$sequence$${key}`;
 

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -566,28 +566,6 @@ export class Repository {
         return await this.fossil.exec(this.repositoryRoot, args, options);
     }
 
-    async config(
-        scope: string,
-        key: string,
-        value: string,
-        options: any
-    ): Promise<string> {
-        const args = ['config'];
-
-        if (scope) {
-            args.push('--' + scope);
-        }
-
-        args.push(key);
-
-        if (value) {
-            args.push(value);
-        }
-
-        const result = await this.exec(args, options);
-        return result.stdout;
-    }
-
     async add(paths?: string[]): Promise<void> {
         const args = ['add'];
 

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -412,16 +412,16 @@ export class Fossil {
 
     async openClone(
         fossilPath: FossilPath,
-        workdir: FossilRoot
+        fossilRoot: FossilRoot
     ): Promise<void> {
-        await this.exec(workdir, ['open', fossilPath]);
+        await this.exec(fossilRoot, ['open', fossilPath]);
     }
 
     async openCloneForce(
         fossilPath: FossilPath,
-        parentPath: FossilRoot
+        fossilRoot: FossilRoot
     ): Promise<void> {
-        await this.exec(parentPath, ['open', fossilPath, '--force']);
+        await this.exec(fossilRoot, ['open', fossilPath, '--force']);
     }
 
     /**

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -606,18 +606,11 @@ export class Repository {
         }
     }
 
-    async update(
-        treeish: FossilCheckin,
-        opts?: { discard: boolean }
-    ): Promise<void> {
+    async update(checkin: FossilCheckin): Promise<void> {
         const args = ['update'];
 
-        if (opts?.discard) {
-            args.push('--dry-run');
-        }
-
-        if (treeish) {
-            args.push(treeish);
+        if (checkin) {
+            args.push(checkin);
         }
 
         await this.exec(args);

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -159,6 +159,7 @@ export class FossilFinder {
         if (match) {
             return match[1].split('.').map(s => parseInt(s)) as FossilVersion;
         }
+        this.logger.log(`Failed to parse fossil version from output: '${raw}'`);
         return [0] as FossilVersion;
     }
 

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -801,29 +801,6 @@ export class Repository {
         return match[2] as FossilUndoCommand;
     }
 
-    async revertFiles(treeish: string, paths: string[]): Promise<void> {
-        const args: string[] = ['revert'];
-
-        if (paths?.length) {
-            args.push(...paths);
-        }
-
-        try {
-            await this.exec(args);
-        } catch (err) {
-            // In case there are merge conflicts to be resolved, fossil reset will output
-            // some "needs merge" data. We try to get around that.
-            if (
-                err instanceof FossilError &&
-                /([^:]+: needs merge\n)+/m.test(err.stdout || '')
-            ) {
-                return;
-            }
-
-            throw err;
-        }
-    }
-
     async pull(options: PullOptions): Promise<void> {
         let args = ['pull'];
 

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -140,7 +140,7 @@ interface FossilSpawnOptions extends cp.SpawnOptionsWithoutStdio {
 }
 
 export class FossilFinder {
-    constructor(private logger: FossilFindAttemptLogger) {}
+    constructor(private readonly logger: FossilFindAttemptLogger) {}
 
     private logAttempt(path: string) {
         this.logger.log(path);
@@ -361,7 +361,7 @@ export class Fossil {
     private readonly outputChannel: OutputChannel;
     public readonly version: FossilVersion;
     private openRepository: Repository | undefined;
-    private _onOutput = new EventEmitter<string>();
+    private readonly _onOutput = new EventEmitter<string>();
     get onOutput(): Event<string> {
         return this._onOutput.event;
     }

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -554,16 +554,12 @@ export interface CommitDetails extends Commit {
 export class Repository {
     constructor(private _fossil: Fossil, private repositoryRoot: FossilRoot) {}
 
-    get fossil(): Fossil {
-        return this._fossil;
-    }
-
     get root(): FossilRoot {
         return this.repositoryRoot;
     }
 
     async exec(args: string[], options: any = {}): Promise<IExecutionResult> {
-        return await this.fossil.exec(this.repositoryRoot, args, options);
+        return await this._fossil.exec(this.repositoryRoot, args, options);
     }
 
     async add(paths?: string[]): Promise<void> {

--- a/src/fossilBase.ts
+++ b/src/fossilBase.ts
@@ -967,7 +967,7 @@ export class Repository {
     /**
      * @param line: line from `fossil status` of `fossil timeline --verbose`
      */
-    parseStatusLine(line: string): IFileStatus | undefined {
+    private parseStatusLine(line: string): IFileStatus | undefined {
         // regexp:
         // 1) (?:\s{3})? at the start of the line there are 0 or 3 spaces
         // 2) ([A-Z_]+) single uppercase word
@@ -1020,13 +1020,13 @@ export class Repository {
         return result;
     }
 
-    async getExtras(): Promise<string> {
+    async getExtras(): Promise<IFileStatus[]> {
         const args = ['extras'];
         const executionResult = await this.exec(args);
-        return executionResult.stdout;
+        return this.parseExtrasLines(executionResult.stdout);
     }
 
-    parseExtrasLines(extraString: string): IFileStatus[] {
+    private parseExtrasLines(extraString: string): IFileStatus[] {
         const result: IFileStatus[] = [];
         const lines = extraString.split('\n');
         lines.forEach(line => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,5 +109,5 @@ export async function activate(
         new Disposable(() => Disposable.from(...disposables).dispose())
     );
 
-    return await init(context, disposables).catch(err => console.error(err));
+    return init(context, disposables).catch(err => console.error(err));
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -91,7 +91,7 @@ export class Model implements Disposable {
     private configurationChangeDisposable: Disposable;
     private readonly disposables: Disposable[] = [];
 
-    constructor(private _hg: Fossil) {
+    constructor(private readonly fossil: Fossil) {
         this.enabled = typedConfig.enabled;
         this.configurationChangeDisposable = workspace.onDidChangeConfiguration(
             this.onDidChangeConfiguration,
@@ -255,7 +255,7 @@ export class Model implements Disposable {
         }
 
         try {
-            const repositoryRoot = await this._hg.getRepositoryRoot(path);
+            const repositoryRoot = await this.fossil.getRepositoryRoot(path);
 
             // This can happen whenever `path` has the wrong case sensitivity in
             // case insensitive file systems
@@ -265,7 +265,7 @@ export class Model implements Disposable {
                 return true;
             }
 
-            const repository = new Repository(this._hg.open(repositoryRoot));
+            const repository = new Repository(this.fossil.open(repositoryRoot));
 
             this.open(repository);
             return true;

--- a/src/model.ts
+++ b/src/model.ts
@@ -179,9 +179,13 @@ export class Model implements Disposable {
         for (const folder of workspace.workspaceFolders || []) {
             const root = folder.uri.fsPath;
             const children = await fs.readdir(root, { withFileTypes: true });
-            children
-                .filter(child => child.isDirectory())
-                .some(child => this.tryOpenRepository(child.name));
+            for (const child of children) {
+                if (child.isDirectory()) {
+                    await this.tryOpenRepository(
+                        Uri.joinPath(folder.uri, child.name).fsPath
+                    );
+                }
+            }
         }
     }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -62,6 +62,12 @@ function isParent(parent: string, child: string): boolean {
     return child.startsWith(parent);
 }
 
+/**
+ *
+ * 1) Model should manage list of Repository objects
+ *    in vscode's source control panel
+ * 2) Model is exposed as fossil Extension API
+ */
 export class Model implements Disposable {
     private _onDidOpenRepository = new EventEmitter<Repository>();
     readonly onDidOpenRepository: Event<Repository> =
@@ -193,6 +199,7 @@ export class Model implements Disposable {
         this.possibleHgRepositoryPaths.clear();
     }
 
+    // An event that is emitted when a workspace folder is added or removed.
     private async onDidChangeWorkspaceFolders({
         added,
         removed,

--- a/src/model.ts
+++ b/src/model.ts
@@ -89,7 +89,7 @@ export class Model implements Disposable {
 
     private enabled = false;
     private configurationChangeDisposable: Disposable;
-    private disposables: Disposable[] = [];
+    private readonly disposables: Disposable[] = [];
 
     constructor(private _hg: Fossil) {
         this.enabled = typedConfig.enabled;
@@ -161,7 +161,7 @@ export class Model implements Disposable {
         this.openRepositories = [];
 
         this.possibleHgRepositoryPaths.clear();
-        this.disposables = dispose(this.disposables);
+        dispose(this.disposables);
     }
 
     /**

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -432,7 +432,7 @@ export class Repository implements IDisposable, InteractionAPI {
         return this.repository.root;
     }
 
-    private disposables: Disposable[] = [];
+    private readonly disposables: Disposable[] = [];
     public statusPromise: Promise<StatusString>;
 
     constructor(private readonly repository: BaseRepository) {
@@ -1239,6 +1239,6 @@ export class Repository implements IDisposable, InteractionAPI {
     }
 
     dispose(): void {
-        this.disposables = dispose(this.disposables);
+        dispose(this.disposables);
     }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -447,11 +447,7 @@ export class Repository implements IDisposable, InteractionAPI {
             repoRootWatcher.onDidCreate,
             repoRootWatcher.onDidDelete
         );
-        const onRepositoryFilesChange = filterEvent(
-            onRepositoryChange,
-            uri => !/\/\.fslckout$/.test(uri.path)
-        );
-        onRepositoryFilesChange(this.onFSChange, this, this.disposables);
+        onRepositoryChange(this.onFSChange, this, this.disposables);
 
         const onCheckoutDatabaseChange = filterEvent(onRepositoryChange, uri =>
             /\/\.fslckout$/.test(uri.path)

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -880,14 +880,14 @@ export class Repository implements IDisposable, InteractionAPI {
 
     @throttle
     async pull(options: PullOptions): Promise<void> {
-        await this.runWithProgress(Operation.Pull, async () => {
+        return this.runWithProgress(Operation.Pull, async () => {
             await this.repository.pull(options);
         });
     }
 
     @throttle
     async push(_path: FossilURI | undefined): Promise<void> {
-        return await this.runWithProgress(Operation.Push, async () => {
+        return this.runWithProgress(Operation.Push, async () => {
             try {
                 await this.repository.push();
             } catch (e) {
@@ -914,7 +914,7 @@ export class Repository implements IDisposable, InteractionAPI {
     ): Promise<IMergeResult> {
         return this.runWithProgress(Operation.Merge, async () => {
             try {
-                return await this.repository.merge(revQuery, mergeAction);
+                return this.repository.merge(revQuery, mergeAction);
             } catch (e) {
                 if (
                     e instanceof FossilError &&
@@ -954,7 +954,7 @@ export class Repository implements IDisposable, InteractionAPI {
         // TODO@Joao: should we make this a general concept?
         await this.whenIdleAndFocused();
 
-        return await this.runWithProgress(Operation.Show, async () => {
+        return this.runWithProgress(Operation.Show, async () => {
             const relativePath = path
                 .relative(this.repository.root, params.path)
                 .replace(/\\/g, '/');
@@ -965,7 +965,7 @@ export class Repository implements IDisposable, InteractionAPI {
                         ' checkin: ' +
                         params.checkin
                 );
-                return await this.repository.cat(relativePath, params.checkin!);
+                return this.repository.cat(relativePath, params.checkin!);
             } catch (e) {
                 if (e instanceof FossilError) {
                     if (e.fossilErrorCode === 'NoSuchFile') {
@@ -1132,7 +1132,7 @@ export class Repository implements IDisposable, InteractionAPI {
         )})`;
 
         if (left && right) {
-            return await commands.executeCommand<void>(
+            return commands.executeCommand<void>(
                 'vscode.diff',
                 left,
                 right,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -538,6 +538,9 @@ export class Repository implements IDisposable, InteractionAPI {
         await delay(5000);
     }
 
+    /**
+     *  wait till all operations are complete and the window is in focus
+     */
     async whenIdleAndFocused(): Promise<void> {
         while (true) {
             if (this.operations.size !== 0) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -808,12 +808,9 @@ export class Repository implements IDisposable, InteractionAPI {
     }
 
     @throttle
-    async update(
-        treeish: FossilCheckin,
-        opts?: { discard: boolean }
-    ): Promise<void> {
+    async update(checkin: FossilCheckin): Promise<void> {
         await this.runWithProgress(Operation.Update, () =>
-            this.repository.update(treeish, opts)
+            this.repository.update(checkin)
         );
     }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1202,11 +1202,7 @@ export class Repository implements IDisposable, InteractionAPI {
 
         const fileStat = this.repository
             .parseStatusLines(statusString)
-            .concat(
-                this.repository.parseExtrasLines(
-                    await this.repository.getExtras()
-                )
-            );
+            .concat(await this.repository.getExtras());
 
         const currentRef = await currentRefPromise;
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -5,7 +5,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, Command, EventEmitter, Event } from 'vscode';
-import { FossilBranch, IRepoStatus } from './fossilBase';
 import { anyEvent, dispose } from './util';
 import { AutoInOutStatuses, AutoInOutState } from './autoinout';
 import * as nls from 'vscode-nls';
@@ -16,11 +15,6 @@ const enum SyncStatus {
     None = 0,
     Pushing = 1,
     Pulling = 2,
-}
-
-interface CurrentRef {
-    ref: FossilBranch | undefined;
-    icon: string;
 }
 
 class ScopeStatusBar {
@@ -38,36 +32,18 @@ class ScopeStatusBar {
         );
     }
 
-    chooseCurrentRef(
-        currentBranch: FossilBranch | undefined,
-        repoStatus: IRepoStatus | undefined
-    ): CurrentRef {
-        const mergeIcon = repoStatus?.isMerge
-            ? '$(git-merge)'
-            : '$(git-branch)';
-        return { ref: currentBranch, icon: mergeIcon };
-    }
-
     get command(): Command | undefined {
         const { currentBranch, repoStatus } = this.repository;
-        const currentRef: CurrentRef = this.chooseCurrentRef(
-            currentBranch,
-            repoStatus
-        );
-
-        if (!currentRef.ref) {
+        if (!currentBranch) {
             return undefined;
         }
-
-        const label = currentRef.ref;
+        const icon = repoStatus?.isMerge ? '$(git-merge)' : '$(git-branch)';
         const title =
-            currentRef.icon +
+            icon +
             ' ' +
-            label +
-            (this.repository.workingGroup.resourceStates.length > 0
-                ? '+'
-                : '') +
-            (this.repository.mergeGroup.resourceStates.length > 0 ? '!' : '');
+            currentBranch +
+            (this.repository.workingGroup.resourceStates.length ? '+' : '') +
+            (this.repository.mergeGroup.resourceStates.length ? '!' : '');
 
         return {
             command: 'fossil.branchChange',

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -205,9 +205,9 @@ class SyncStatusBar {
 }
 
 export class StatusBarCommands {
-    private syncStatusBar: SyncStatusBar;
-    private scopeStatusBar: ScopeStatusBar;
-    private disposables: Disposable[] = [];
+    private readonly syncStatusBar: SyncStatusBar;
+    private readonly scopeStatusBar: ScopeStatusBar;
+    private readonly disposables: Disposable[] = [];
 
     constructor(repository: Repository) {
         this.syncStatusBar = new SyncStatusBar(repository);
@@ -242,6 +242,6 @@ export class StatusBarCommands {
     dispose(): void {
         this.syncStatusBar.dispose();
         this.scopeStatusBar.dispose();
-        this.disposables = dispose(this.disposables);
+        dispose(this.disposables);
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,15 +10,15 @@ export interface IDisposable {
     dispose(): void;
 }
 
-interface HasForEach<T> {
-    forEach: (val: (item: T) => void) => void;
-}
-
 export function dispose<T extends IDisposable>(
-    disposables: HasForEach<T>
-): T[] {
+    disposables: Set<T> | T[]
+): void {
     disposables.forEach(d => d.dispose());
-    return [];
+    if (disposables instanceof Set) {
+        disposables.clear();
+    } else {
+        disposables.length = 0;
+    }
 }
 
 export function toDisposable(dispose: () => void): IDisposable {


### PR DESCRIPTION
Remove all hg references from the ts code. Source control panel updates are much more robust now.