### PR TITLE
fix: use remote names to push and pull

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1129,9 +1129,9 @@ export class CommandCenter {
         if (!remotes.length) {
             return interaction.warnNoRemotes();
         }
-        const uri = await interaction.pickRemote(remotes, 'pull from');
-        if (uri) {
-            await repository.pull(uri);
+        const name = await interaction.pickRemote(remotes, 'pull from');
+        if (name) {
+            await repository.pull(name);
         }
     }
 
@@ -1252,9 +1252,9 @@ export class CommandCenter {
         if (!remotes.length) {
             return interaction.warnNoRemotes();
         }
-        const uri = await interaction.pickRemote(remotes, 'push to');
-        if (uri) {
-            await repository.push(uri);
+        const name = await interaction.pickRemote(remotes, 'push to');
+        if (name) {
+            await repository.push(name);
         }
     }
 

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -39,6 +39,7 @@ import {
     RelativePath,
     StashID,
     FossilRemote,
+    FossilRemoteName,
 } from './openedRepository';
 import * as humanise from './humanise';
 import { Repository, LogEntriesOptions } from './repository';
@@ -970,13 +971,14 @@ interface RemoteQuickPickItem extends QuickPickItem {
 export async function pickRemote(
     remotes: FossilRemote[],
     what: 'push to' | 'pull from'
-): Promise<FossilURI | undefined> {
+): Promise<FossilRemoteName | undefined> {
     if (remotes.length == 1) {
-        return remotes[0].uri;
+        return remotes[0].name;
     }
     const picks = remotes.map(
-        (remote): RemoteQuickPickItem => ({
+        (remote): RemoteQuickPickItem & { name: FossilRemoteName } => ({
             label: `$(link) ${remote.name}`,
+            name: remote.name,
             detail: remote.uri.toString(),
             uri: remote.uri,
         })
@@ -986,7 +988,7 @@ export async function pickRemote(
         placeHolder,
         matchOnDetail: true,
     });
-    return choice?.uri;
+    return choice?.name;
 }
 
 export function warnUnsavedChanges(msg: string): void {

--- a/src/openedRepository.ts
+++ b/src/openedRepository.ts
@@ -450,12 +450,12 @@ export class OpenedRepository {
         return match[2] as FossilUndoCommand;
     }
 
-    async pull(uri: Uri): Promise<void> {
-        await this.exec(['pull', uri.toString()]);
+    async pull(name: FossilRemoteName): Promise<void> {
+        await this.exec(['pull', name]);
     }
 
-    async push(uri: FossilURI | undefined): Promise<void> {
-        await this.exec(['push', ...(uri ? [uri.toString()] : [])]);
+    async push(name: FossilRemoteName | undefined): Promise<void> {
+        await this.exec(['push', ...(name ? [name] : [])]);
     }
 
     async merge(

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -29,7 +29,6 @@ import {
     MergeAction,
     FossilHash,
     FossilRemote,
-    FossilURI,
     FossilUndoCommand,
     FossilCommitMessage,
     StashItem,
@@ -41,6 +40,7 @@ import {
     AnyPath,
     UserPath,
     StashID,
+    FossilRemoteName,
 } from './openedRepository';
 import {
     anyEvent,
@@ -827,16 +827,16 @@ export class Repository implements IDisposable, InteractionAPI {
     }
 
     @throttle
-    async pull(uri: FossilURI): Promise<void> {
+    async pull(name: FossilRemoteName): Promise<void> {
         return this.runWithProgress(Operation.Pull, async () => {
-            await this.repository.pull(uri);
+            await this.repository.pull(name);
         });
     }
 
     @throttle
-    async push(uri?: FossilURI): Promise<void> {
+    async push(name?: FossilRemoteName): Promise<void> {
         return this.runWithProgress(Operation.Push, async () => {
-            await this.repository.push(uri);
+            await this.repository.push(name);
         });
     }
 

--- a/src/test/suite/stateSuite.ts
+++ b/src/test/suite/stateSuite.ts
@@ -59,10 +59,7 @@ function PullAndPushSuite(this: Suite): void {
         await commands.executeCommand('fossil.pull');
         sinon.assert.calledOnce(listCall);
         sinon.assert.notCalled(sem);
-        sinon.assert.calledOnceWithExactly(pullCall, [
-            'pull',
-            'https://example.com/',
-        ]);
+        sinon.assert.calledOnceWithExactly(pullCall, ['pull', 'default']);
     });
 
     test('Update', async () => {
@@ -95,10 +92,7 @@ function PullAndPushSuite(this: Suite): void {
 
     test('PushTo (one remote)', async () => {
         const pushCall = await oneRemote('fossil.pushTo');
-        sinon.assert.calledOnceWithExactly(pushCall, [
-            'push',
-            'https://example.com/',
-        ]);
+        sinon.assert.calledOnceWithExactly(pushCall, ['push', 'default']);
     });
 
     test('PushTo (two remotes)', async () => {
@@ -123,7 +117,7 @@ function PullAndPushSuite(this: Suite): void {
         await commands.executeCommand('fossil.pushTo');
         sinon.assert.calledOnce(listCall);
         sinon.assert.calledOnce(sqp);
-        sinon.assert.calledOnceWithExactly(pushCall, ['push', 'ssh://fossil']);
+        sinon.assert.calledOnceWithExactly(pushCall, ['push', 'origin']);
     });
 
     test('PushTo (two remotes, do not pick)', async () => {


### PR DESCRIPTION
using uri caused fossil to not use saved authentication